### PR TITLE
go1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.15', '1.16']
+        go: ['1.16', '1.17']
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
@@ -41,10 +41,10 @@ jobs:
       with:
           fetch-depth: 0
     - name: Run tests
-      if: ${{ matrix.go != '1.16' }}
+      if: ${{ matrix.go != '1.17' }}
       run: go test -race ./...
     - name: Run tests & generate coverage report
-      if: ${{ matrix.go == '1.16' }}
+      if: ${{ matrix.go == '1.17' }}
       run: |
         COVERPKG=$(go list ./... | tr '\n' ,)
         COVERPKG=${COVERPKG%?}

--- a/pkg/replay/replay_test.go
+++ b/pkg/replay/replay_test.go
@@ -3,7 +3,6 @@ package replay
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -60,8 +59,7 @@ func TestIn(t *testing.T) {
 			kase.ServeHTTP(rec, req)
 			res := rec.Result()
 
-			// TODO: use io.ReadAll when support for Go 1.15 is dropped
-			got, err := ioutil.ReadAll(res.Body)
+			got, err := io.ReadAll(res.Body)
 			require.NoError(t, err)
 
 			assert.Equal(t, http.StatusConflict, res.StatusCode)
@@ -146,8 +144,7 @@ func TestInRegionHandlerForRegion(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	res := rec.Result()
 
-	// TODO: use io.ReadAll when support for Go 1.15 is dropped
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	assert.Equal(t, "executed", string(body))
 }
@@ -165,8 +162,7 @@ func TestInRegionHandlerForOtherRegion(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	res := rec.Result()
 
-	// TODO: use io.ReadAll when support for Go 1.15 is dropped
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	assert.Equal(t, "Conflict\n", string(body))


### PR DESCRIPTION
This PR drops support for Go 1.15 and adds support for Go 1.16.